### PR TITLE
Return 504 instead of 408 when worker times out

### DIFF
--- a/ores/wsgi/responses.py
+++ b/ores/wsgi/responses.py
@@ -45,7 +45,7 @@ def unknown_error(message):
 
 
 def timeout_error(message=None):
-    return error(408, 'request_timeout',
+    return error(504, 'request_timeout',
                  message or ("Cannot process your request because the " +
                              "server timed out."))
 


### PR DESCRIPTION
4xx codes means there is something wrong with the client
but this it's something wrong with the server.

Change-Id: I6d9f981da4c56f4737492c016a96ad8be0b96088