### PR TITLE
Make sure the ORES client always closes sockets

### DIFF
--- a/ores/api.py
+++ b/ores/api.py
@@ -1,6 +1,8 @@
 """
 This module provides a :class:`ores.api.Session` class that can maintain a
-connection to an instance of ORES and efficiently generate scores.
+client connection to an instance of ORES and efficiently generate scores.
+
+Batching and parallelism are set by constructor arguments.
 
 .. autoclass:: ores.api.Session
     :members:
@@ -107,7 +109,8 @@ class Session:
         start = time.time()
         response = requests.get(url, params=params,
                                 headers=self.headers,
-                                verify=True, stream=True)
+                                verify=True)
+
         try:
             doc = response.json()
         except ValueError:


### PR DESCRIPTION
The requests `stream` parameter is probably unnecessary in our case, and can
cause issues where the socket isn't closed if an exception or other issue
causes us to not fully read the response.

Bug: T213582