### PR TITLE
Fixes injection bug for multiple rev_ids/models

### DIFF
--- a/ores/utilities/test_api.py
+++ b/ores/utilities/test_api.py
@@ -87,28 +87,28 @@ def main(argv=None):
 
     make_request(
         ores_url,
-        "/v3/scores/testwiki/?revids=1234|2345&feature.delay=2&features",
+        "/v3/scores/testwiki/?revids=1205|2309&feature.delay=2&features",
         is_json=True,
         equal_to={"testwiki": {
             "models": {"revid": {"version": "0.0.0"}},
             "scores": {
-                "1234": {"revid": {
+                "1205": {"revid": {
                     "score": {
                         "prediction": False,
-                        "probability": {"false": 0.57, "true": 0.43}},
+                        "probability": {"false": 0.50, "true": 0.50}},
                     "features": {
                         "feature.delay": 2,
-                        "feature.revision.reversed_last_two_in_rev_id": 43}
+                        "feature.revision.reversed_last_two_in_rev_id": 50}
                 }},
-                "2345": {"revid": {
+                "2309": {"revid": {
                     "score": {
                         "prediction": True,
-                        "probability": {"false": 0.46, "true": 0.54}},
+                        "probability": {"false": 0.09999999999999998, "true": 0.90}},
                     "features": {
                         "feature.delay": 2,
-                        "feature.revision.reversed_last_two_in_rev_id": 54}}
+                        "feature.revision.reversed_last_two_in_rev_id": 90}}
                 }}
-            }})
+        }})
 
     other_wiki_event = {
         "comment": "/* K-O */", "database": "enwiki",

--- a/ores/utilities/test_api.py
+++ b/ores/utilities/test_api.py
@@ -85,6 +85,31 @@ def main(argv=None):
                                     'type': 'TimeoutError'}}
             }}}})
 
+    make_request(
+        ores_url,
+        "/v3/scores/testwiki/?revids=1234|2345&feature.delay=2&features",
+        is_json=True,
+        equal_to={"testwiki": {
+            "models": {"revid": {"version": "0.0.0"}},
+            "scores": {
+                "1234": {"revid": {
+                    "score": {
+                        "prediction": False,
+                        "probability": {"false": 0.57, "true": 0.43}},
+                    "features": {
+                        "feature.delay": 2,
+                        "feature.revision.reversed_last_two_in_rev_id": 43}
+                }},
+                "2345": {"revid": {
+                    "score": {
+                        "prediction": True,
+                        "probability": {"false": 0.46, "true": 0.54}},
+                    "features": {
+                        "feature.delay": 2,
+                        "feature.revision.reversed_last_two_in_rev_id": 54}}
+                }}
+            }})
+
     other_wiki_event = {
         "comment": "/* K-O */", "database": "enwiki",
         "meta": {

--- a/ores/wsgi/util.py
+++ b/ores/wsgi/util.py
@@ -88,7 +88,7 @@ def build_score_request(scoring_system, request, context_name=None, rev_id=None,
     model_names = parse_model_names(request, model_name)
     precache = 'precache' in request.args
     include_features = 'features' in request.args
-    injection_caches = parse_injection(request, rev_id)
+    injection_caches = parse_injection(request, rev_ids)
     model_info = parse_model_info(request)
 
     if context_name and context_name in scoring_system and not model_names:
@@ -122,30 +122,30 @@ def parse_model_names(request, model_name):
         return read_bar_split_param(request, "models", type=str)
 
 
-def parse_injection(request, rev_id):
+def parse_injection(request, rev_ids):
     """Parse values for features / datasources of interest."""
     cache = {}
 
     if 'inject' in request.values:
         try:
-            cache = json.loads(request.values['inject'])
+            cache = {int(rev_id): injection
+                     for rev_id, injection in json.loads(request.values['inject']).items()}
         except json.JSONDecodeError as e:
             raise CacheParsingError(e)
 
-    if rev_id is not None:
-        rev_cache = cache
+    rev_cache = {}
+    try:
+        for k, v in request.values.items():
+            if k.startswith(("feature.", "datasource.")):
+                rev_cache[k] = json.loads(v)
+    except json.JSONDecodeError as e:
+        raise CacheParsingError(e)
 
-        try:
-            for k, v in request.values.items():
-                if k.startswith(("feature.", "datasource.")):
-                    rev_cache[k] = json.loads(v)
-        except json.JSONDecodeError as e:
-            raise CacheParsingError(e)
-
-        if len(rev_cache) > 0:
-            cache = {rev_id: rev_cache}
-    else:
-        cache = {int(rev_id): c for rev_id, c in cache.items()}
+    if len(rev_cache) > 0:
+        for rev_id in rev_ids:
+          c = cache.get(rev_id) or {}
+          c.update(rev_cache)
+          cache[rev_id] = c
 
     return cache or None
 

--- a/ores/wsgi/util.py
+++ b/ores/wsgi/util.py
@@ -143,9 +143,9 @@ def parse_injection(request, rev_ids):
 
     if len(rev_cache) > 0:
         for rev_id in rev_ids:
-          c = cache.get(rev_id) or {}
-          c.update(rev_cache)
-          cache[rev_id] = c
+            c = cache.get(rev_id) or {}
+            c.update(rev_cache)
+            cache[rev_id] = c
 
     return cache or None
 

--- a/tests/wsgi/tests/test_util.py
+++ b/tests/wsgi/tests/test_util.py
@@ -1,5 +1,6 @@
 import flask
 import pytest
+
 from ores.applications.wsgi import build
 from ores.scoring_systems.scoring_system import ScoringSystem
 from ores.wsgi.util import (build_precache_map, build_score_request,
@@ -48,8 +49,11 @@ def test_build_score_request_(app):
         }
         assert actual == expected
 
-def test_build_score_request_(app):
-    with app.test_request_context('/?models=foo&revids=123|234&feature.foo.bar=1', environ_base={'REMOTE_ADDR': '127.0.0.1'}):
+
+def test_build_score_request_injection(app):
+    with app.test_request_context(
+            '/?models=foo&revids=123|234&feature.foo.bar=1',
+            environ_base={'REMOTE_ADDR': '127.0.0.1'}):
         scoring_system = ScoringSystem({})
         actual = build_score_request(scoring_system, flask.request, context_name='testwiki', rev_id=None).to_json()
 

--- a/tests/wsgi/tests/test_util.py
+++ b/tests/wsgi/tests/test_util.py
@@ -48,6 +48,23 @@ def test_build_score_request_(app):
         }
         assert actual == expected
 
+def test_build_score_request_(app):
+    with app.test_request_context('/?models=foo&revids=123|234&feature.foo.bar=1', environ_base={'REMOTE_ADDR': '127.0.0.1'}):
+        scoring_system = ScoringSystem({})
+        actual = build_score_request(scoring_system, flask.request, context_name='testwiki', rev_id=None).to_json()
+
+        expected = {
+            'context': 'testwiki',
+            'include_features': False,
+            'injection_caches': {123: {"feature.foo.bar": 1}, 234: {"feature.foo.bar": 1}},
+            'ip': '127.0.0.1',
+            'model_info': [],
+            'model_names': ['foo'],
+            'precache': False,
+            'rev_ids': [234, 123]
+        }
+        assert actual == expected
+
 
 def test_build_precache_map():
     precache_config = {


### PR DESCRIPTION
This allows feature injection to work when specifying rev_ids via the `revids=1234|1344` URL param.  