### PR TITLE
Build: Python 3.7 base image & layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim-stretch
+FROM python:3.7-slim-stretch
 
 RUN apt-get update && apt-get install -y \
     g++ \
@@ -6,18 +6,16 @@ RUN apt-get update && apt-get install -y \
     libblas-dev \
     liblapack-dev \
     libopenblas-dev \
-    python3-dev \
     enchant \
     build-essential
+COPY requirements.txt /ores/requirements.txt
+COPY test-requirements.txt /ores/test-requirements.txt
+RUN pip install pip --upgrade && pip install wheel && pip install nltk \
+    && pip install -r /ores/requirements.txt \
+    && pip install -r /ores/test-requirements.txt \
+    && python -m nltk.downloader stopwords
 
 COPY . /ores
 WORKDIR /ores
-
-RUN pip install pip --upgrade
-RUN pip install wheel
-RUN pip install nltk
-RUN pip install -r /ores/requirements.txt
-RUN pip install -r /ores/test-requirements.txt
-RUN python -m nltk.downloader stopwords
 
 EXPOSE 8080


### PR DESCRIPTION
This PR updates the Dockerfile to use a Python3.7 base image, introduces layer caching to speed up build times and also has a change to reduce the overall image size.