### PR TITLE
Fix: replaces in wsgi score.js should be global

### DIFF
--- a/ores/wsgi/static/js/scorer.js
+++ b/ores/wsgi/static/js/scorer.js
@@ -80,7 +80,7 @@ function createTable( data ) {
 }
 
 function getResults() {
-	var revs = $( '#revIds' ).val().replace( ',', '|' ),
+	var revs = $( '#revIds' ).val().replace( /,/g, '|' ),
 		modelsUrl = '',
 		url = '',
 		container = '<div id="tableContainer" class="col-md-6 col-md-offset-3" style="margin-top: 3em; margin-bottom: 3em;">',
@@ -126,7 +126,7 @@ if ( getParameterByName( 'wiki' ) ) {
 if ( getParameterByName( 'revids' ) ) {
 	$( function () {
 		setTimeout( function () {
-			$( '#revIds' ).val( getParameterByName( 'revids' ).replace( '|', ',' ) );
+			$( '#revIds' ).val( getParameterByName( 'revids' ).replace( /\|/g, ',' ) );
 		}, 3000 );
 	} );
 }


### PR DESCRIPTION
Pretty simple fix so I didn't go with a phab ticket. Currently the [WSGI UI](https://ores.wikimedia.org/ui/) (which I suspect very few people use, so this is very low impact) states it allows for entering multiple rev IDs that are comma separated, but if you attempt to do so with three or more, it errors due to "1,2,3" being changed to "1|2,3" instead of what the server expects which is "1|2|3". I tested it locally and it worked as expected.

(Force-pushed to correct a typo in a commit message.)