### PR TITLE
Fix for handling invalid model_info parameter for scores rest call

### DIFF
--- a/ores/wsgi/routes/v3/util.py
+++ b/ores/wsgi/routes/v3/util.py
@@ -91,6 +91,8 @@ def build_v3_context_model_map(score_request, scoring_system):
                     model_name, score_request.model_info or ['version'])
                 context_models_doc[context_name]['models'][model_name] = model_doc
         return util.jsonify(context_models_doc)
+    except ModelInfoLookupError as e:
+        return responses.model_info_lookup_error(e)
     except Exception:
         return responses.unknown_error(traceback.format_exc())
 

--- a/tests/wsgi/tests/test_server.py
+++ b/tests/wsgi/tests/test_server.py
@@ -123,6 +123,18 @@ def test_scores_v3(client):
     assert json.loads(res.get_data().decode('utf-8')) == \
            {'testwiki': {'models': {'revid': {'version': '0.0.0'}}}}
 
+def test_scores_v3_model_info_valid(client):
+    res = client.get('/v3/scores/?model_info=type', follow_redirects=True)
+    assert res.status_code == 200
+    assert json.loads(res.get_data().decode('utf-8')) == \
+           {'testwiki': {'models': {'revid': {'type': 'RevIDScorer'}}}}
+
+def test_scores_v3_model_info_invalid(client):
+    res = client.get('/v3/scores/?model_info=foo', follow_redirects=True)
+    assert res.status_code == 400
+    assert json.loads(res.get_data().decode('utf-8')) == \
+           {'error': {'code': 'bad request', 'message': "Model information could not be retrieved for 'foo'"}}
+
 
 def test_scores_v3_context(client):
     res = client.get('/v3/scores/testwiki/', follow_redirects=True)


### PR DESCRIPTION
Kindly review the fix for the [T279271-ORES gives internal error on an invalid model_info parameter ](https://phabricator.wikimedia.org/T279271) along with py tests. I have run all test cases and have 100% pass rate.

Regards,
Ethan