### PR TITLE
Fix for flask dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ sseclient >= 0.0.18
 stopit >= 1.1.1, < 1.1.999
 werkzeug == 0.16.1
 yamlconf >= 0.2.4, < 0.2.999
-jinja2 == 3.0.3
-itsdangerous==2.0.1
+jinja2 == 2.11.3
+itsdangerous == 1.1.0
+markupsafe == 1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ sseclient >= 0.0.18
 stopit >= 1.1.1, < 1.1.999
 werkzeug == 0.16.1
 yamlconf >= 0.2.4, < 0.2.999
+jinja2 == 3.0.3
+itsdangerous==2.0.1


### PR DESCRIPTION
Hello,

Fix for [T309862-ORES server does not start due to flask dependency conflicts](https://phabricator.wikimedia.org/T309862)

Pinning version of Jinja2 and itsdangerous to make the application launch after installations. Other choice is to upgrade flask itself but I think that is more risky.

Regards,
Ethan