### PR TITLE
Update requirements.txt to avoid Github's security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-celery >= 4.4.0, < 4.4.999
+celery >= 5.2.2, < 5.2.999
 docopt >= 0.6.2, < 0.6.999
 flask >= 1.0.2, < 1.0.999
 flask-jsonpify >= 1.5.0, < 1.5.999
 flask-swaggerui >= 0.0.1, < 0.0.999
 flask-wikimediaui >= 0.0.1, < 0.0.999
 mwapi >= 0.5.0, < 0.5.999
-pyyaml == 4.2b4
+pyyaml == 5.4
 redis >= 3.2.1, < 4.0.0
 revscoring >= 2.3.0, < 2.8.999
 sseclient >= 0.0.18


### PR DESCRIPTION
At Wikimedia we have been using Celery 5.2.6 and PyYaml 5.4
since we switched to Python 3.7. Update the requirements.txt
file to avoid Github's Dependabot alerts.